### PR TITLE
Fix vue-tsc errors on production build

### DIFF
--- a/playground/vue/src/pages/blocking.vue
+++ b/playground/vue/src/pages/blocking.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { ref, version } from 'vue'
 
-import BottomSheet from 'vue-spring-bottom-sheet'
-import 'vue-spring-bottom-sheet/dist/style.css'
+import BottomSheet from '@douxcode/vue-spring-bottom-sheet'
+import '@douxcode/vue-spring-bottom-sheet/dist/style.css'
 
 const bottomSheet = ref<InstanceType<typeof BottomSheet>>()
 const open = ref(false)

--- a/playground/vue/src/pages/index.vue
+++ b/playground/vue/src/pages/index.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { ref, version } from 'vue'
 
-import BottomSheet from 'vue-spring-bottom-sheet'
-import 'vue-spring-bottom-sheet/dist/style.css'
+import BottomSheet from '@douxcode/vue-spring-bottom-sheet'
+import '@douxcode/vue-spring-bottom-sheet/dist/style.css'
 
 const bottomSheet = ref<InstanceType<typeof BottomSheet>>()
 

--- a/playground/vue/src/pages/snap.vue
+++ b/playground/vue/src/pages/snap.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { ref, version } from 'vue'
 
-import BottomSheet from 'vue-spring-bottom-sheet'
-import 'vue-spring-bottom-sheet/dist/style.css'
+import BottomSheet from '@douxcode/vue-spring-bottom-sheet'
+import '@douxcode/vue-spring-bottom-sheet/dist/style.css'
 
 const bottomSheet = ref<InstanceType<typeof BottomSheet>>()
 const maxHeight = ref(0)

--- a/playground/vue/src/pages/sticky.vue
+++ b/playground/vue/src/pages/sticky.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { ref, version } from 'vue'
 
-import BottomSheet from 'vue-spring-bottom-sheet'
-import 'vue-spring-bottom-sheet/dist/style.css'
+import BottomSheet from '@douxcode/vue-spring-bottom-sheet'
+import '@douxcode/vue-spring-bottom-sheet/dist/style.css'
 
 const bottomSheet = ref<InstanceType<typeof BottomSheet>>()
 

--- a/src/BottomSheet.vue
+++ b/src/BottomSheet.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import type { BottomSheetProps } from './types.ts'
+
 import { computed, nextTick, onMounted, ref, toRefs, watch } from 'vue'
 
 import { clamp, funnel } from 'remeda'
@@ -9,17 +11,7 @@ import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
 
 import { useSnapPoints } from './composables/useSnapPoints.ts'
 
-interface IProps {
-  duration?: number
-  snapPoints?: number[]
-  defaultSnapPoint?: number
-  blocking?: boolean
-  canSwipeClose?: boolean
-  canBackdropClose?: boolean
-  expandOnContentDrag?: boolean
-}
-
-const props = withDefaults(defineProps<IProps>(), {
+const props = withDefaults(defineProps<BottomSheetProps>(), {
   blocking: true,
   canSwipeClose: true,
   canBackdropClose: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import BottomSheet from './BottomSheet.vue'
+export * from './types.ts'
 
 export default BottomSheet

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export interface BottomSheetProps {
+  duration?: number
+  snapPoints?: number[]
+  defaultSnapPoint?: number
+  blocking?: boolean
+  canSwipeClose?: boolean
+  canBackdropClose?: boolean
+  expandOnContentDrag?: boolean
+}

--- a/tsconfig.app.tsbuildinfo
+++ b/tsconfig.app.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./src/index.ts","./src/vite-env.d.ts","./src/composables/usesnappoints.ts","./src/bottomsheet.vue"],"version":"5.6.3"}
+{"root":["./src/index.ts","./src/types.ts","./src/vite-env.d.ts","./src/composables/usesnappoints.ts","./src/bottomsheet.vue"],"version":"5.6.3"}


### PR DESCRIPTION
This PR includes fix for https://github.com/megaarmos/vue-spring-bottom-sheet/issues/6#issue-2825194412

- Fix playground library name for local link
- Moved Props types to a separate file