### PR TITLE
fix: ensure numeric sorting for snapPoints

### DIFF
--- a/src/composables/useSnapPoints.ts
+++ b/src/composables/useSnapPoints.ts
@@ -1,7 +1,7 @@
 import { computed, type Ref } from 'vue'
 
 export function useSnapPoints(snapPoints: Ref<number[]>, height: Ref<number>) {
-  const sortedSnapPoints = computed(() => snapPoints.value.sort())
+  const sortedSnapPoints = computed(() => snapPoints.value.sort((a, b) => a - b))
 
   const minSnap = computed(() => sortedSnapPoints.value[0])
   const maxSnap = computed(() => sortedSnapPoints.value[sortedSnapPoints.value.length - 1])


### PR DESCRIPTION
```js
// error [60, 400, 800] -> [400, 60, 800]
const sortedSnapPoints = computed(() => snapPoints.value.sort()
```