### PR TITLE
feat(snap): added snapped emit event

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Assuming there is `const bottomSheet = ref()`
 | dragging-up    | Emitted when user drags sheet upward   | -               |
 | dragging-down  | Emitted when user drags sheet downward | -               |
 | instinctHeight | Emitted when content height changes    | height (number) |
+| snapped | Emitted when sheet finishes snapping    | snapPointIndex (number) |
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Assuming there is `const bottomSheet = ref()`
 | dragging-up    | Emitted when user drags sheet upward   | -               |
 | dragging-down  | Emitted when user drags sheet downward | -               |
 | instinctHeight | Emitted when content height changes    | height (number) |
-| snapped | Emitted when sheet finishes snapping    | snapPointIndex (number) |
+| snapped        | Emitted when sheet finishes snapping   | snapPointIndex (number) |
 
 ## Acknowledgments
 

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "packages/vue-spring-bottom-sheet": {
       "name": "@douxcode/vue-spring-bottom-sheet",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "dependencies": {
         "@vueuse/core": "^13.0.0",
         "@vueuse/integrations": "^13.0.0",

--- a/packages/vue-spring-bottom-sheet/src/BottomSheet.vue
+++ b/packages/vue-spring-bottom-sheet/src/BottomSheet.vue
@@ -26,6 +26,7 @@ const emit = defineEmits<{
   (e: 'ready'): void
   (e: 'dragging-up'): void
   (e: 'dragging-down'): void
+  (e: 'snapped', snapPointIndex?: number): void
   (e: 'instinctHeight', instinctHeight: number): void
   (e: 'update:modelValue'): void
 }>()
@@ -243,6 +244,7 @@ const snapToPoint = (index: number) => {
   controls = animate(heightValue, height.value, {
     duration: props.duration / 1000,
     ease: 'easeInOut',
+    onComplete: () => emit('snapped', snapPointsRef.value.indexOf(snapPointsRef.value[index])),
   })
 }
 
@@ -332,6 +334,11 @@ const handlePanEnd = () => {
   controls = animate(heightValue, height.value, {
     duration: props.duration / 1000,
     ease: 'easeInOut',
+    onComplete: () =>
+      emit(
+        'snapped',
+        snapPointsRef.value.indexOf(snapPointsRef.value[closestSnapPointIndex.value]),
+      ),
   })
   controls = animate(translateYValue, 0, {
     duration: props.duration / 1000,


### PR DESCRIPTION
I stumbled upon a usecase on my personnal project where I need to retrieve an emitted event when the sheet finishes snapping (whether it is a manual snap or a programmatic one).
What do you think about this implementation?

I chose to emit the current snapped snapPointIndex value rather than the value itself for consistency purposes, as a snap point value can now be either a percentage viewport value or a number.

Another justification for the emitted value would be that now the ```snapToPoint``` method accepts a snapPointIndex so with this emitted event it would be very easy to keep track of the currentSnapIndex in our code ✨