### PR TITLE
fix: compatiblity with `motion-v` 1.5.0

### DIFF
--- a/apps/playground/pages/blocking.vue
+++ b/apps/playground/pages/blocking.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { ref, version } from 'vue'
 
-import BottomSheet from '@douxcode/vue-spring-bottom-sheet'
-import '@douxcode/vue-spring-bottom-sheet/dist/style.css'
+import BottomSheet from '../../../packages/vue-spring-bottom-sheet'
+import '../../../packages/vue-spring-bottom-sheet/dist/style.css'
 
 const bottomSheet = ref<InstanceType<typeof BottomSheet>>()
 const open = ref(false)

--- a/apps/playground/pages/index.vue
+++ b/apps/playground/pages/index.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { ref, version } from 'vue'
 
-import BottomSheet from '@douxcode/vue-spring-bottom-sheet'
-import '@douxcode/vue-spring-bottom-sheet/dist/style.css'
+import BottomSheet from '../../../packages/vue-spring-bottom-sheet'
+import '../../../packages/vue-spring-bottom-sheet/dist/style.css'
 
 const bottomSheet = ref<InstanceType<typeof BottomSheet>>()
 

--- a/apps/playground/pages/snap.vue
+++ b/apps/playground/pages/snap.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { ref, version } from 'vue'
 
-import BottomSheet from '@douxcode/vue-spring-bottom-sheet'
-import '@douxcode/vue-spring-bottom-sheet/dist/style.css'
+import BottomSheet from '../../../packages/vue-spring-bottom-sheet'
+import '../../../packages/vue-spring-bottom-sheet/dist/style.css'
 
 const bottomSheet = ref<InstanceType<typeof BottomSheet>>()
 const instinctHeight = ref(0)

--- a/apps/playground/pages/sticky.vue
+++ b/apps/playground/pages/sticky.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { ref, version } from 'vue'
 
-import BottomSheet from '@douxcode/vue-spring-bottom-sheet'
-import '@douxcode/vue-spring-bottom-sheet/dist/style.css'
+import BottomSheet from '../../../packages/vue-spring-bottom-sheet'
+import '../../../packages/vue-spring-bottom-sheet/dist/style.css'
 
 const bottomSheet = ref<InstanceType<typeof BottomSheet>>()
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,20 +22,20 @@
       "dependencies": {
         "@nuxt/icon": "1.12.0",
         "@nuxt/ui": "3.0.2",
-        "nuxt": "^3.16.2",
+        "nuxt": "^3.17.3",
         "typescript": "^5.8.3",
-        "vue": "^3.5.13",
-        "vue-router": "^4.5.0",
+        "vue": "^3.5.14",
+        "vue-router": "^4.5.1",
       },
     },
     "packages/vue-spring-bottom-sheet": {
       "name": "@douxcode/vue-spring-bottom-sheet",
-      "version": "2.2.2",
+      "version": "2.4.0",
       "dependencies": {
         "@vueuse/core": "^13.2.0",
         "@vueuse/integrations": "^13.2.0",
         "focus-trap": "^7.6.4",
-        "motion-v": "^1.0.2",
+        "motion-v": "^1.5.0",
         "remeda": "^2.21.6",
         "vue": "^3.5.14",
       },
@@ -1154,7 +1154,7 @@
 
     "fraction.js": ["fraction.js@4.3.7", "", {}, "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew=="],
 
-    "framer-motion": ["framer-motion@12.5.0", "", { "dependencies": { "motion-dom": "^12.5.0", "motion-utils": "^12.5.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-buPlioFbH9/W7rDzYh1C09AuZHAk2D1xTA1BlounJ2Rb9aRg84OXexP0GLd+R83v0khURdMX7b5MKnGTaSg5iA=="],
+    "framer-motion": ["framer-motion@12.22.0", "", { "dependencies": { "motion-dom": "^12.22.0", "motion-utils": "^12.19.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-qG07rR8/mboCNU34nORbrIbBXbJzP4aDqBdr67TAIVlMryDEOwh7LXjylWovlnPCMg78ExoY0Gn2F1fV+3DNIw=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
@@ -1524,11 +1524,11 @@
 
     "module-definition": ["module-definition@5.0.1", "", { "dependencies": { "ast-module-types": "^5.0.0", "node-source-walk": "^6.0.1" }, "bin": { "module-definition": "bin/cli.js" } }, "sha512-kvw3B4G19IXk+BOXnYq/D/VeO9qfHaapMeuS7w7sNUqmGaA6hywdFHMi+VWeR9wUScXM7XjoryTffCZ5B0/8IA=="],
 
-    "motion-dom": ["motion-dom@12.6.5", "", { "dependencies": { "motion-utils": "^12.6.5" } }, "sha512-jpM9TQLXzYMWMJ7Ec7sAj0iis8oIuu6WvjI3yNKJLdrZyrsI/b2cRInDVL8dCl683zQQq19DpL9cSMP+k8T1NA=="],
+    "motion-dom": ["motion-dom@12.22.0", "", { "dependencies": { "motion-utils": "^12.19.0" } }, "sha512-ooH7+/BPw9gOsL9VtPhEJHE2m4ltnhMlcGMhEqA0YGNhKof7jdaszvsyThXI6LVIKshJUZ9/CP6HNqQhJfV7kw=="],
 
-    "motion-utils": ["motion-utils@12.6.5", "", {}, "sha512-IsOeKsOF+FWBhxQEDFBO6ZYC8/jlidmVbbLpe9/lXSA9j9kzGIMUuIBx2SZY+0reAS0DjZZ1i7dJp4NHrjocPw=="],
+    "motion-utils": ["motion-utils@12.19.0", "", {}, "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw=="],
 
-    "motion-v": ["motion-v@1.0.2", "", { "dependencies": { "@vueuse/core": "^10.0.0", "framer-motion": "12.5.0", "hey-listen": "^1.0.8", "motion-dom": "^12.5.0" }, "peerDependencies": { "vue": ">=3.0.0" } }, "sha512-Qn/X9Mx/5g02rjvpGtn5fht2OWTAnZoed4vLXgjM0lJgkSEtoGuadwEVypbCVH3WW1AHsns2k2okKAjpDrKu6A=="],
+    "motion-v": ["motion-v@1.5.0", "", { "dependencies": { "@vueuse/core": "^10.0.0", "framer-motion": "12.22.0", "hey-listen": "^1.0.8", "motion-dom": "12.22.0" }, "peerDependencies": { "vue": ">=3.0.0" } }, "sha512-AIwI0U0ZlxDgdtjZKNzSpUo+X3IKRUGNqrdf+hig3TIehxgFds4gSL3amqsx9iZIGjYnGDdlwuqxKPYR1cxiTQ=="],
 
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 

--- a/packages/vue-spring-bottom-sheet/package.json
+++ b/packages/vue-spring-bottom-sheet/package.json
@@ -62,7 +62,7 @@
     "@vueuse/core": "^13.2.0",
     "@vueuse/integrations": "^13.2.0",
     "focus-trap": "^7.6.4",
-    "motion-v": "^1.0.2",
+    "motion-v": "^1.5.0",
     "remeda": "^2.21.6",
     "vue": "^3.5.14"
   },

--- a/packages/vue-spring-bottom-sheet/src/BottomSheet.vue
+++ b/packages/vue-spring-bottom-sheet/src/BottomSheet.vue
@@ -190,26 +190,27 @@ const open = async () => {
   heightValue.set(height.value)
   translateYValue.set(height.value)
 
-  controls = animate(heightValue, height.value, {
-    duration: props.duration / 1000,
-    ease: 'easeInOut',
-  })
-  controls = animate(translateYValue, 0, {
-    duration: props.duration / 1000,
-    ease: 'easeInOut',
+  requestAnimationFrame(() => {
+    controls = animate(heightValue, height.value, {
+      duration: props.duration / 1000,
+      ease: 'easeInOut',
+    })
+
+    controls = animate(translateYValue, 0, {
+      duration: props.duration / 1000,
+      ease: 'easeInOut',
+      onComplete: () => {
+        if (props.blocking) {
+          emit('opened')
+          focusTrap.activate()
+        }
+      },
+    })
   })
 
   window.addEventListener('keydown', handleEscapeKey)
 
   isOpening = false
-  if (props.blocking) {
-    setTimeout(() => {
-      if (heightValue.get() < 1) {
-        emit('opened')
-        focusTrap.activate()
-      }
-    }, props.duration)
-  }
 }
 
 let isClosing = false
@@ -367,7 +368,9 @@ const handleContentPanStart = (_: PointerEvent, info: PanInfo) => {
   height.value = sheetHeight.value
   translateY.value = translateYValue.get()
 
-  controls.stop()
+  if (controls) {
+    controls.stop()
+  }
 
   if (!sheetScroll.value) return
 

--- a/packages/vue-spring-bottom-sheet/src/BottomSheet.vue
+++ b/packages/vue-spring-bottom-sheet/src/BottomSheet.vue
@@ -187,8 +187,8 @@ const open = async () => {
 
   translateY.value = height.value
 
-  heightValue.set(height.value)
-  translateYValue.set(height.value)
+  heightValue.jump(height.value)
+  translateYValue.jump(height.value)
 
   requestAnimationFrame(() => {
     controls = animate(heightValue, height.value, {
@@ -551,7 +551,7 @@ defineExpose({ open, close, snapToPoint })
           v-if="showSheet"
           ref="sheet"
           :exit="{ y: '100%', height: sheetHeight }"
-          :initial="{ y: '100%' }"
+          :initial="false"
           :style="{ y: translateYValue, height: heightValue }"
           :data-vsbs-shadow="!blocking"
           :data-vsbs-sheet-show="showSheet"

--- a/packages/vue-spring-bottom-sheet/tsconfig.app.tsbuildinfo
+++ b/packages/vue-spring-bottom-sheet/tsconfig.app.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./src/index.ts","./src/types.ts","./src/vite-env.d.ts","./src/composables/usesnappoints.ts","./src/utils/heightpercenttopixels.ts","./src/utils/rubberbandifoutofbounds.ts","./src/bottomsheet.vue"],"version":"5.6.3"}
+{"root":["./src/index.ts","./src/types.ts","./src/vite-env.d.ts","./src/composables/useSnapPoints.ts","./src/utils/heightPercentToPixels.ts","./src/utils/rubberbandIfOutOfBounds.ts","./src/BottomSheet.vue"],"version":"5.6.3"}

--- a/packages/vue-spring-bottom-sheet/tsconfig.node.json
+++ b/packages/vue-spring-bottom-sheet/tsconfig.node.json
@@ -6,14 +6,12 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
-    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
 
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Closes #29 

- (Main fix) use `requestAnimationFrame()` to make sure browser properly animates properties
- Move `emit('opened')` and `focusTrap.activate()` logic into the `onComplete` callback of the `translateY` animation instead of using a `setTimeout` to ensure the event is fired upon animation completion
- Properly stop animations on drag start by checking for controls
- Remove initial y state to fix the first instance not sometimes
- `jump` instead of `set` `heightValue`/`translateYValue`
- Makes sure playground uses local version for development