### PR TITLE
fix: Target <Motion> component's $el for focus fallback

### DIFF
--- a/packages/vue-spring-bottom-sheet/src/BottomSheet.vue
+++ b/packages/vue-spring-bottom-sheet/src/BottomSheet.vue
@@ -105,7 +105,7 @@ const isWindowRootScrollLocked = useScrollLock(document.documentElement)
 
 const focusTrap = useFocusTrap([sheet, backdrop], {
   immediate: false,
-  fallbackFocus: () => sheet.value.$el || document.body,
+  fallbackFocus: () => sheet.value?.$el || document.body,
 })
 
 function handleTouchMove(event: TouchEvent) {

--- a/packages/vue-spring-bottom-sheet/src/BottomSheet.vue
+++ b/packages/vue-spring-bottom-sheet/src/BottomSheet.vue
@@ -105,7 +105,7 @@ const isWindowRootScrollLocked = useScrollLock(document.documentElement)
 
 const focusTrap = useFocusTrap([sheet, backdrop], {
   immediate: false,
-  fallbackFocus: () => sheet.value || document.body,
+  fallbackFocus: () => sheet.value.$el || document.body,
 })
 
 function handleTouchMove(event: TouchEvent) {


### PR DESCRIPTION
Removes a `Maximum call stack size exceeded` error when opening the sheet. 

Targeting the <Motion ref="sheet" /> component directly seems to cause recursive updates to state. This adjustment targets the underlying HTML Element of the sheet ref component instead of the reactive ref.

Admittedly, I haven't tested this super well at all, so not sure if there are any unintentional side-effects. I'll let the author decide if this is a robust enough fix. I've just patched my local version in the meantime.